### PR TITLE
MacOS Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 include_directories(${DXFLIB_INCLUDE_DIR})
 
 # tinyxml.
-if (WIN32)
+if (WIN32 OR APPLE)
     set(TINYXML_ROOT_DIRECTORY "" CACHE PATH "Path to tinyxml root directory")
     
     if (NOT TINYXML_ROOT_DIRECTORY)
@@ -166,6 +166,10 @@ endif()
 # Mac OS X Core Foundation & Bundle creation.
 if (APPLE)
     FIND_LIBRARY(COREFOUNDATION_LIBRARY CoreFoundation)
+
+    find_library(LIBZIP_LIBRARY NAMES zip PATHS "/opt/homebrew/lib")
+    include_directories("/opt/homebrew/include")
+
     include(MacInstaller.cmake)
 endif()
 
@@ -181,7 +185,12 @@ if (UNIX AND NOT APPLE)
 endif()
 
 if (APPLE)
-    target_link_libraries(conducteo PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::PrintSupport ${COREFOUNDATION_LIBRARY})
+    target_link_libraries(conducteo PRIVATE
+            Qt${QT_VERSION_MAJOR}::Widgets
+            Qt${QT_VERSION_MAJOR}::PrintSupport
+            ${COREFOUNDATION_LIBRARY}
+            ${LIBZIP_LIBRARY}
+    )
 endif()
 
 if(QT_VERSION_MAJOR EQUAL 6)

--- a/MacInstaller.cmake
+++ b/MacInstaller.cmake
@@ -33,16 +33,16 @@ set_source_files_properties(${rt_db} PROPERTIES MACOSX_PACKAGE_LOCATION Resource
 
 # Docx template.
 file (GLOB mac_docx_template "${CMAKE_SOURCE_DIR}/install/templates/model_fr.docx" )
-set_source_files_properties(${mac_docx_template} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
+set_source_files_properties(${mac_docx_template} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/templates)
 
 file (GLOB mac_docx_template_2 "${CMAKE_SOURCE_DIR}/install/templates/model_2_fr.docx" )
-set_source_files_properties(${mac_docx_template_2} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
+set_source_files_properties(${mac_docx_template_2} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/templates)
 
 file (GLOB mac_docx_template_3 "${CMAKE_SOURCE_DIR}/install/templates/model_en.docx" )
-set_source_files_properties(${mac_docx_template_3} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
+set_source_files_properties(${mac_docx_template_3} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/templates)
 
 file (GLOB mac_docx_template_4 "${CMAKE_SOURCE_DIR}/install/templates/model_2_en.docx" )
-set_source_files_properties(${mac_docx_template_4} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
+set_source_files_properties(${mac_docx_template_4} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/templates)
 
 file(GLOB mac_translations "${CMAKE_SOURCE_DIR}/install/translations/*.json")
 set_source_files_properties(${mac_translations}

--- a/MacInstaller.cmake
+++ b/MacInstaller.cmake
@@ -4,54 +4,54 @@ set_source_files_properties(${bundle_icon} PROPERTIES MACOSX_PACKAGE_LOCATION Re
 
 # Documentation.
 file (GLOB pdf_docs "${CMAKE_SOURCE_DIR}/install/documentation.pdf" )
-set_source_files_properties(${pdf_docs} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/documentation)
+set_source_files_properties(${pdf_docs} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/documentation)
 
 file (GLOB pdf_docs_2 "${CMAKE_SOURCE_DIR}/install/validations.pdf" )
-set_source_files_properties(${pdf_docs_2} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/documentation)
+set_source_files_properties(${pdf_docs_2} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/documentation)
 
 file (GLOB pdf_docs_3 "${CMAKE_SOURCE_DIR}/install/tutorial.pdf" )
-set_source_files_properties(${pdf_docs_3} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/documentation)
+set_source_files_properties(${pdf_docs_3} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/documentation)
 
 file (GLOB pdf_docs_4 "${CMAKE_SOURCE_DIR}/install/quickstart.pdf" )
-set_source_files_properties(${pdf_docs_4} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/documentation)
+set_source_files_properties(${pdf_docs_4} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/documentation)
 
 file(GLOB_RECURSE validations_data_en10211 "${CMAKE_SOURCE_DIR}/validations/data/en10211/*.c2d")
 file(GLOB_RECURSE validations_data_common  "${CMAKE_SOURCE_DIR}/validations/data/common/*.c2d")
 
-set_source_files_properties(${validations_data_en10211} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/exemples)
-set_source_files_properties(${validations_data_common} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/exemples)
+set_source_files_properties(${validations_data_en10211} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/examples)
+set_source_files_properties(${validations_data_common} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/examples)
 
 file(GLOB_RECURSE validations_data_en10077 "${CMAKE_SOURCE_DIR}/validations/data/en10077/*.c2d")
-set_source_files_properties(${validations_data_en10077} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/exemples)
+set_source_files_properties(${validations_data_en10077} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/examples)
 
 file(GLOB_RECURSE tutorial_data "${CMAKE_SOURCE_DIR}/documentation/tutorial/*.c2d")
-set_source_files_properties(${tutorial_data} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/exemples)
+set_source_files_properties(${tutorial_data} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/examples)
 
 # RT 2012 database.
 file (GLOB rt_db "${CMAKE_SOURCE_DIR}/install/rt2012.db" )
-set_source_files_properties(${rt_db} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS)
+set_source_files_properties(${rt_db} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
 # Docx template.
 file (GLOB mac_docx_template "${CMAKE_SOURCE_DIR}/install/model_fr.docx" )
-set_source_files_properties(${mac_docx_template} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/docx)
+set_source_files_properties(${mac_docx_template} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
 
 file (GLOB mac_docx_template_2 "${CMAKE_SOURCE_DIR}/install/model_2_fr.docx" )
-set_source_files_properties(${mac_docx_template_2} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/docx)
+set_source_files_properties(${mac_docx_template_2} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
 
 file (GLOB mac_docx_template_3 "${CMAKE_SOURCE_DIR}/install/model_en.docx" )
-set_source_files_properties(${mac_docx_template_3} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/docx)
+set_source_files_properties(${mac_docx_template_3} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
 
 file (GLOB mac_docx_template_4 "${CMAKE_SOURCE_DIR}/install/model_2_en.docx" )
-set_source_files_properties(${mac_docx_template_4} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/docx)
+set_source_files_properties(${mac_docx_template_4} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
 
 file(GLOB mac_translations "${CMAKE_SOURCE_DIR}/install/translations/*.json")
 set_source_files_properties(${mac_translations}
-        PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/translations
+        PROPERTIES MACOSX_PACKAGE_LOCATION Resources/translations
 )
 
 # Examples.
-file (GLOB examples "${CMAKE_SOURCE_DIR}/install/exemples/*.c2d" )
-set_source_files_properties(${examples} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/exemples)
+file (GLOB examples "${CMAKE_SOURCE_DIR}/install/examples/*.c2d" )
+set_source_files_properties(${examples} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/examples)
 
 set(MACOSXResources ${bundle_icon} ${pdf_docs} ${pdf_docs_2} ${pdf_docs_4} ${rt_db} ${mac_translations} ${examples} ${mac_docx_template} ${mac_docx_template_2} ${mac_docx_template_3} ${mac_docx_template_4} ${validations_data_en10211} ${validations_data_en10077} ${validations_data_common} ${tutorial_data} ${pdf_docs_3})
 

--- a/MacInstaller.cmake
+++ b/MacInstaller.cmake
@@ -44,11 +44,16 @@ set_source_files_properties(${mac_docx_template_3} PROPERTIES MACOSX_PACKAGE_LOC
 file (GLOB mac_docx_template_4 "${CMAKE_SOURCE_DIR}/install/model_2_en.docx" )
 set_source_files_properties(${mac_docx_template_4} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/docx)
 
+file(GLOB mac_translations "${CMAKE_SOURCE_DIR}/install/translations/*.json")
+set_source_files_properties(${mac_translations}
+        PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/translations
+)
+
 # Examples.
 file (GLOB examples "${CMAKE_SOURCE_DIR}/install/exemples/*.c2d" )
 set_source_files_properties(${examples} PROPERTIES MACOSX_PACKAGE_LOCATION MacOS/exemples)
 
-set(MACOSXResources ${bundle_icon} ${pdf_docs} ${pdf_docs_2} ${pdf_docs_4} ${rt_db} ${examples} ${mac_docx_template} ${mac_docx_template_2} ${mac_docx_template_3} ${mac_docx_template_4} ${validations_data_en10211} ${validations_data_en10077} ${validations_data_common} ${tutorial_data} ${pdf_docs_3})
+set(MACOSXResources ${bundle_icon} ${pdf_docs} ${pdf_docs_2} ${pdf_docs_4} ${rt_db} ${mac_translations} ${examples} ${mac_docx_template} ${mac_docx_template_2} ${mac_docx_template_3} ${mac_docx_template_4} ${validations_data_en10211} ${validations_data_en10077} ${validations_data_common} ${tutorial_data} ${pdf_docs_3})
 
 # set bundle informations.
 set( MACOSX_BUNDLE_INFO_STRING          "conducteö"                                                                                         )

--- a/MacInstaller.cmake
+++ b/MacInstaller.cmake
@@ -3,16 +3,16 @@ set(bundle_icon "${CMAKE_SOURCE_DIR}/resources/conducteo.icns")
 set_source_files_properties(${bundle_icon} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
 # Documentation.
-file (GLOB pdf_docs "${CMAKE_SOURCE_DIR}/install/documentation.pdf" )
+file (GLOB pdf_docs "${CMAKE_SOURCE_DIR}/install/documentation/documentation.pdf" )
 set_source_files_properties(${pdf_docs} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/documentation)
 
-file (GLOB pdf_docs_2 "${CMAKE_SOURCE_DIR}/install/validations.pdf" )
+file (GLOB pdf_docs_2 "${CMAKE_SOURCE_DIR}/install/documentation/validations.pdf" )
 set_source_files_properties(${pdf_docs_2} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/documentation)
 
-file (GLOB pdf_docs_3 "${CMAKE_SOURCE_DIR}/install/tutorial.pdf" )
+file (GLOB pdf_docs_3 "${CMAKE_SOURCE_DIR}/install/documentation/tutorial.pdf" )
 set_source_files_properties(${pdf_docs_3} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/documentation)
 
-file (GLOB pdf_docs_4 "${CMAKE_SOURCE_DIR}/install/quickstart.pdf" )
+file (GLOB pdf_docs_4 "${CMAKE_SOURCE_DIR}/install/documentation/quickstart.pdf" )
 set_source_files_properties(${pdf_docs_4} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/documentation)
 
 file(GLOB_RECURSE validations_data_en10211 "${CMAKE_SOURCE_DIR}/validations/data/en10211/*.c2d")
@@ -28,20 +28,20 @@ file(GLOB_RECURSE tutorial_data "${CMAKE_SOURCE_DIR}/documentation/tutorial/*.c2
 set_source_files_properties(${tutorial_data} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/examples)
 
 # RT 2012 database.
-file (GLOB rt_db "${CMAKE_SOURCE_DIR}/install/rt2012.db" )
-set_source_files_properties(${rt_db} PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+file (GLOB rt_db "${CMAKE_SOURCE_DIR}/install/data/rt2012.db" )
+set_source_files_properties(${rt_db} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/data)
 
 # Docx template.
-file (GLOB mac_docx_template "${CMAKE_SOURCE_DIR}/install/model_fr.docx" )
+file (GLOB mac_docx_template "${CMAKE_SOURCE_DIR}/install/templates/model_fr.docx" )
 set_source_files_properties(${mac_docx_template} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
 
-file (GLOB mac_docx_template_2 "${CMAKE_SOURCE_DIR}/install/model_2_fr.docx" )
+file (GLOB mac_docx_template_2 "${CMAKE_SOURCE_DIR}/install/templates/model_2_fr.docx" )
 set_source_files_properties(${mac_docx_template_2} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
 
-file (GLOB mac_docx_template_3 "${CMAKE_SOURCE_DIR}/install/model_en.docx" )
+file (GLOB mac_docx_template_3 "${CMAKE_SOURCE_DIR}/install/templates/model_en.docx" )
 set_source_files_properties(${mac_docx_template_3} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
 
-file (GLOB mac_docx_template_4 "${CMAKE_SOURCE_DIR}/install/model_2_en.docx" )
+file (GLOB mac_docx_template_4 "${CMAKE_SOURCE_DIR}/install/templates/model_2_en.docx" )
 set_source_files_properties(${mac_docx_template_4} PROPERTIES MACOSX_PACKAGE_LOCATION Resources/docx)
 
 file(GLOB mac_translations "${CMAKE_SOURCE_DIR}/install/translations/*.json")
@@ -56,7 +56,7 @@ set_source_files_properties(${examples} PROPERTIES MACOSX_PACKAGE_LOCATION Resou
 set(MACOSXResources ${bundle_icon} ${pdf_docs} ${pdf_docs_2} ${pdf_docs_4} ${rt_db} ${mac_translations} ${examples} ${mac_docx_template} ${mac_docx_template_2} ${mac_docx_template_3} ${mac_docx_template_4} ${validations_data_en10211} ${validations_data_en10077} ${validations_data_common} ${tutorial_data} ${pdf_docs_3})
 
 set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
-    
+
 # set bundle informations.
 set( MACOSX_BUNDLE_INFO_STRING          "conducteö"                                                                                         )
 set( MACOSX_BUNDLE_ICON_FILE            "conducteo.icns"                                                                                    )

--- a/MacInstaller.cmake
+++ b/MacInstaller.cmake
@@ -55,6 +55,8 @@ set_source_files_properties(${examples} PROPERTIES MACOSX_PACKAGE_LOCATION Resou
 
 set(MACOSXResources ${bundle_icon} ${pdf_docs} ${pdf_docs_2} ${pdf_docs_4} ${rt_db} ${mac_translations} ${examples} ${mac_docx_template} ${mac_docx_template_2} ${mac_docx_template_3} ${mac_docx_template_4} ${validations_data_en10211} ${validations_data_en10077} ${validations_data_common} ${tutorial_data} ${pdf_docs_3})
 
+set(CMAKE_OSX_DEPLOYMENT_TARGET "11.0")
+    
 # set bundle informations.
 set( MACOSX_BUNDLE_INFO_STRING          "conducteö"                                                                                         )
 set( MACOSX_BUNDLE_ICON_FILE            "conducteo.icns"                                                                                    )

--- a/src/tools/UiTools.cpp
+++ b/src/tools/UiTools.cpp
@@ -79,7 +79,7 @@ QString UiTools::getCurrentDate()
 
 QString UiTools::getBinaryDir()
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(__APPLE__)
     return QApplication::applicationDirPath();
 #else
     return "/usr/bin";
@@ -88,7 +88,7 @@ QString UiTools::getBinaryDir()
 
 QString UiTools::getDataDir()
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(__APPLE__)
     return QApplication::applicationDirPath();
 #else
     return "/usr/share/conducteo/data";
@@ -97,7 +97,7 @@ QString UiTools::getDataDir()
 
 QString UiTools::getDocumentationDir()
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(__APPLE__)
     return QApplication::applicationDirPath() + "/documentation";
 #else
     return "/usr/share/doc/conducteo";
@@ -106,7 +106,7 @@ QString UiTools::getDocumentationDir()
 
 QString UiTools::getExamplesDir()
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(__APPLE__)
     return QApplication::applicationDirPath() + "/examples";
 #else
     return "/usr/share/doc/conducteo/examples";
@@ -115,7 +115,7 @@ QString UiTools::getExamplesDir()
 
 QString UiTools::getTemplatesDir()
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(__APPLE__)
     return QApplication::applicationDirPath() + "/templates";
 #else
     return "/usr/share/conducteo/templates";
@@ -124,7 +124,7 @@ QString UiTools::getTemplatesDir()
 
 QString UiTools::getTranslationsDir()
 {
-#ifdef WIN32
+#if defined(WIN32) || defined(__APPLE__)
     return QApplication::applicationDirPath() + "/translations";
 #else
     return "/usr/share/conducteo/translations";

--- a/src/tools/UiTools.cpp
+++ b/src/tools/UiTools.cpp
@@ -20,6 +20,7 @@
 #include <LinguistManager.h>
 #include <QApplication>
 #include <QDateTime>
+#include <QDir>
 
 QString UiTools::getSoftwareVersion()
 {
@@ -77,6 +78,18 @@ QString UiTools::getCurrentDate()
     return s_date;
 }
 
+static QString appleResourcesDir()
+{
+#if defined(__APPLE__)
+    QDir dir(QCoreApplication::applicationDirPath());
+    dir.cdUp();
+    dir.cd("Resources");
+    return dir.absolutePath();
+#else
+    return QString();
+#endif
+}
+
 QString UiTools::getBinaryDir()
 {
 #if defined(WIN32) || defined(__APPLE__)
@@ -88,8 +101,10 @@ QString UiTools::getBinaryDir()
 
 QString UiTools::getDataDir()
 {
-#if defined(WIN32) || defined(__APPLE__)
+#if defined(WIN32)
     return QApplication::applicationDirPath();
+#elif defined(__APPLE__)
+    return appleResourcesDir() + "/data";
 #else
     return "/usr/share/conducteo/data";
 #endif
@@ -97,8 +112,10 @@ QString UiTools::getDataDir()
 
 QString UiTools::getDocumentationDir()
 {
-#if defined(WIN32) || defined(__APPLE__)
+#if defined(WIN32)
     return QApplication::applicationDirPath() + "/documentation";
+#elif defined(__APPLE__)
+    return appleResourcesDir() + "/documentation";
 #else
     return "/usr/share/doc/conducteo";
 #endif
@@ -106,8 +123,10 @@ QString UiTools::getDocumentationDir()
 
 QString UiTools::getExamplesDir()
 {
-#if defined(WIN32) || defined(__APPLE__)
+#if defined(WIN32)
     return QApplication::applicationDirPath() + "/examples";
+#elif defined(__APPLE__)
+    return appleResourcesDir() + "/examples";
 #else
     return "/usr/share/doc/conducteo/examples";
 #endif
@@ -115,8 +134,10 @@ QString UiTools::getExamplesDir()
 
 QString UiTools::getTemplatesDir()
 {
-#if defined(WIN32) || defined(__APPLE__)
+#if defined(WIN32)
     return QApplication::applicationDirPath() + "/templates";
+#elif defined(__APPLE__)
+    return appleResourcesDir() + "/templates";
 #else
     return "/usr/share/conducteo/templates";
 #endif
@@ -124,8 +145,10 @@ QString UiTools::getTemplatesDir()
 
 QString UiTools::getTranslationsDir()
 {
-#if defined(WIN32) || defined(__APPLE__)
+#if defined(WIN32)
     return QApplication::applicationDirPath() + "/translations";
+#elif defined(__APPLE__)
+    return appleResourcesDir() + "/translations";
 #else
     return "/usr/share/conducteo/translations";
 #endif


### PR DESCRIPTION
Adds macos build support 

### Changes:
- Added translations in final package
- Fixed data directories

### Note: 
- The application builds and launches fine on macOS Big Sur 11+ (Intel / Apple Silicon): [here](https://github.com/neocle/conducteo/releases/)
- ~There also seems to be an issue with theme/styles because icons are not colored the same as shown on the download page on sourceforge~

Dark Mode
<img width="1280" height="832" alt="Capture d’écran 2026-05-21 à 16 55 30" src="https://github.com/user-attachments/assets/b77119ae-2025-4b8a-b0fd-ca133e9cff94" />

Light Mode
<img width="1280" height="832" alt="Capture d’écran 2026-05-21 à 17 03 32" src="https://github.com/user-attachments/assets/4d1c4010-3546-4ce6-bc2f-08b5b2021f17" />
