### PR TITLE
Make SVG icons theme-aware (first step toward dark mode)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Widgets Core Gui PrintSupport)
+find_package(Qt6 REQUIRED COMPONENTS Widgets Core Gui PrintSupport Svg)
 
 # conducteö headers.
 include_directories("include")
@@ -122,6 +122,7 @@ include_directories("libs/local-data/include")
 include_directories("libs/model-viewer/include")
 include_directories("libs/mouse/include")
 include_directories("libs/states/include")
+include_directories("libs/themed-icons/include")
 include_directories("libs/string/include")
 include_directories("libs/surface-results/include")
 include_directories("libs/temperature/include")
@@ -173,15 +174,15 @@ qt_add_executable(conducteo MANUAL_FINALIZATION MACOSX_BUNDLE ${MACOSXResources}
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if (WIN32)
-    target_link_libraries(conducteo PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::PrintSupport ${LIBZIP_LIBRARY} ${ZLIB_LIBRARY})
+    target_link_libraries(conducteo PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::PrintSupport Qt${QT_VERSION_MAJOR}::Svg ${LIBZIP_LIBRARY} ${ZLIB_LIBRARY})
 endif()
 
 if (UNIX AND NOT APPLE)
-    target_link_libraries(conducteo PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::PrintSupport uuid zip tinyxml Eigen3::Eigen ${DXFLIB_LIBRARY} nlohmann_json::nlohmann_json)
+    target_link_libraries(conducteo PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::PrintSupport Qt${QT_VERSION_MAJOR}::Svg uuid zip tinyxml Eigen3::Eigen ${DXFLIB_LIBRARY} nlohmann_json::nlohmann_json)
 endif()
 
 if (APPLE)
-    target_link_libraries(conducteo PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::PrintSupport ${COREFOUNDATION_LIBRARY})
+    target_link_libraries(conducteo PRIVATE Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::PrintSupport Qt${QT_VERSION_MAJOR}::Svg ${COREFOUNDATION_LIBRARY})
 endif()
 
 if(QT_VERSION_MAJOR EQUAL 6)

--- a/libs/buttons-tab/src/ButtonTabs.cpp
+++ b/libs/buttons-tab/src/ButtonTabs.cpp
@@ -21,6 +21,7 @@
 #include <StatesManager.h>
 #include <model/Model.h>
 #include <Log.h>
+#include "ThemedIcon.h"
 
 ButtonTabs::ButtonTabs(QWidget *parent):
     QWidget(parent),
@@ -173,15 +174,15 @@ void ButtonTabs::translate()
 
 void ButtonTabs::applyTheme()
 {
-    _modelButton.setIcon(QIcon(":/icons/blocks.svg"));
+    _modelButton.setIcon(ThemedIcon::get(":/icons/blocks.svg"));
     _modelButton.setIconSize(QSize(24, 24));
-    _1DModelButton.setIcon(QIcon(":/icons/blocks-backslash.svg"));
+    _1DModelButton.setIcon(ThemedIcon::get(":/icons/blocks-backslash.svg"));
     _1DModelButton.setIconSize(QSize(24, 24));
-    _resultsButton.setIcon(QIcon(":/icons/temperature-sun.svg"));
+    _resultsButton.setIcon(ThemedIcon::get(":/icons/temperature-sun.svg"));
     _resultsButton.setIconSize(QSize(24, 24));
-    _reportButton.setIcon(QIcon(":/icons/report.svg"));
+    _reportButton.setIcon(ThemedIcon::get(":/icons/report.svg"));
     _reportButton.setIconSize(QSize(24, 24));
-    _meshButton.setIcon(QIcon(":/icons/mesh.svg"));
+    _meshButton.setIcon(ThemedIcon::get(":/icons/mesh.svg"));
     _meshButton.setIconSize(QSize(24, 24));
 }
 

--- a/libs/lists/src/SearchInput.cpp
+++ b/libs/lists/src/SearchInput.cpp
@@ -20,6 +20,7 @@
 #include <LinguistManager.h>
 #include <QMouseEvent>
 #include <QPainter>
+#include "ThemedIcon.h"
 
 SearchInput::SearchInput(Qt::Orientation o, QWidget *parent):
     CustomHeaderView(o, parent),
@@ -33,7 +34,7 @@ SearchInput::SearchInput(Qt::Orientation o, QWidget *parent):
             &SearchInput::searchInputTextChanged,
             Qt::UniqueConnection);
 
-    _image = QIcon(":/icons/search.svg").pixmap(10, 10); 
+    _image = ThemedIcon::get(":/icons/search.svg").pixmap(10, 10); 
 }
 
 SearchInput::~SearchInput()

--- a/libs/lists/src/boundary-conditions/BoundaryConditionList.cpp
+++ b/libs/lists/src/boundary-conditions/BoundaryConditionList.cpp
@@ -32,6 +32,7 @@
 #include <QMenu>
 #include <QFile>
 #include <Log.h>
+#include "ThemedIcon.h"
 
 BoundaryConditionList::BoundaryConditionList(QWidget *parent):
     QWidget(parent),
@@ -198,7 +199,7 @@ void BoundaryConditionList::translate()
 
 void BoundaryConditionList::applyTheme()
 {
-    _headers.setIcon(QIcon(":/icons/border-sides.svg").pixmap(16, 16));
+    _headers.setIcon(ThemedIcon::get(":/icons/border-sides.svg").pixmap(16, 16));
 
     QColor themedColor  = QColor(199, 229, 245);
 

--- a/libs/lists/src/environments/EnvironmentList.cpp
+++ b/libs/lists/src/environments/EnvironmentList.cpp
@@ -26,6 +26,7 @@
 #include <StatesManager.h>
 #include <QInputDialog>
 #include <QMenu>
+#include "ThemedIcon.h"
 
 EnvironmentList::EnvironmentList(QWidget *parent):
     QWidget(parent),
@@ -133,7 +134,7 @@ void EnvironmentList::translate()
 
 void EnvironmentList::applyTheme()
 {
-    _headers.setIcon(QIcon(":/icons/layout-collage.svg").pixmap(16, 16));
+    _headers.setIcon(ThemedIcon::get(":/icons/layout-collage.svg").pixmap(16, 16));
 
     QColor themedColor = QColor(199, 229, 245);
 

--- a/libs/lists/src/materials/MaterialCustomItem.cpp
+++ b/libs/lists/src/materials/MaterialCustomItem.cpp
@@ -27,6 +27,7 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QLocale>
+#include "ThemedIcon.h"
 
 #define ItemWidth                       200
 #define ClosedItemHeight                25
@@ -100,7 +101,7 @@ void MaterialCustomItem::paintEvent(QPaintEvent *event)
             image="star-filled.svg";
         if (_hover && !_favorite)
             image="carambola.svg";
-        QPixmap pixmap = QIcon(":/icons/" + image).pixmap(16, 16);
+        QPixmap pixmap = ThemedIcon::get(":/icons/" + image).pixmap(16, 16);
         pixmap = pixmap.scaledToHeight(25, Qt::SmoothTransformation);
         QRect r2(width()-10-pixmap.width(), (25-pixmap.height())/2, pixmap.width(), pixmap.height());
         qp.drawPixmap(r2, pixmap);
@@ -109,7 +110,7 @@ void MaterialCustomItem::paintEvent(QPaintEvent *event)
 
     else if (_extrusion)
     {
-        QPixmap pixmap = QIcon(":/icons/slice.svg").pixmap(16, 16);
+        QPixmap pixmap = ThemedIcon::get(":/icons/slice.svg").pixmap(16, 16);
         pixmap = pixmap.scaledToHeight(25, Qt::SmoothTransformation);
         QRect r2(4, 2, pixmap.width(), pixmap.height());
         qp.drawPixmap(r2, pixmap);

--- a/libs/lists/src/materials/MaterialList.cpp
+++ b/libs/lists/src/materials/MaterialList.cpp
@@ -40,6 +40,7 @@
 #include <tinyxml.h>
 #include <QDrag>
 #include <QMenu>
+#include "ThemedIcon.h"
 
 MaterialList::MaterialList(QWidget *parent):
     QWidget(parent),
@@ -648,7 +649,7 @@ void MaterialList::translate()
 
 void MaterialList::applyTheme()
 {
-    _headers.setIcon(QIcon(":/icons/database.svg").pixmap(16, 16));
+    _headers.setIcon(ThemedIcon::get(":/icons/database.svg").pixmap(16, 16));
 
     QColor themedColor = QColor(199, 229, 245);
 

--- a/libs/model-viewer/src/ModelViewer.cpp
+++ b/libs/model-viewer/src/ModelViewer.cpp
@@ -80,6 +80,7 @@
 
 #define _USE_MATH_DEFINES
 #include <math.h>
+#include "ThemedIcon.h"
 
 #ifdef WIN32
 #define isnan(x) _isnan(x)
@@ -1664,7 +1665,7 @@ void ModelViewer::finalizePolyline()
         dialog.setWindowModality(Qt::ApplicationModal);
         QIcon icon(":/icon.png");
         dialog.setWindowIcon(icon);
-        dialog.setIconPixmap(QIcon(":/icons/alert-circle.svg").pixmap(16, 16));
+        dialog.setIconPixmap(ThemedIcon::get(":/icons/alert-circle.svg").pixmap(16, 16));
         dialog.exec();
         return;
     }
@@ -3770,10 +3771,10 @@ void ModelViewer::zoomChanged()
 
 void ModelViewer::applyTheme()
 {
-    _rotationCursor      = QCursor(QIcon(":/icons/rotate.svg").pixmap(16, 16));
-    _resizeOriginalImage = QIcon(":/icons/arrows-move-horizontal.svg").pixmap(16, 16);
+    _rotationCursor      = QCursor(ThemedIcon::get(":/icons/rotate.svg").pixmap(16, 16));
+    _resizeOriginalImage = ThemedIcon::get(":/icons/arrows-move-horizontal.svg").pixmap(16, 16);
 
-    _en13370Button.setIcon(QIcon(":/icons/calculator.svg").pixmap(16, 16));
+    _en13370Button.setIcon(ThemedIcon::get(":/icons/calculator.svg").pixmap(16, 16));
 }
 
 // RGB color arrays.
@@ -3960,7 +3961,7 @@ void ModelViewer::importSelectedElements()
         dialog.setWindowModality(Qt::ApplicationModal);
         QIcon icon(":/icon.png");
         dialog.setWindowIcon(icon);
-        dialog.setIconPixmap(QIcon(":/icons/alert-circle.svg").pixmap(16, 16));
+        dialog.setIconPixmap(ThemedIcon::get(":/icons/alert-circle.svg").pixmap(16, 16));
         dialog.exec();
 
         ActionsManager::instance()->removeAction(action);

--- a/libs/model-viewer/src/TranslationBoard.cpp
+++ b/libs/model-viewer/src/TranslationBoard.cpp
@@ -19,6 +19,7 @@
 #include <TranslationBoard.h>
 #include <LinguistManager.h>
 #include <QPainter>
+#include "ThemedIcon.h"
 
 TranslationBoard::TranslationBoard(Direction direction, QWidget *parent):
     QWidget(parent),
@@ -67,13 +68,13 @@ void TranslationBoard::applyTheme()
 {
     if (_direction==Vertical)
     {
-        _increase.setIcon(QIcon(":/icons/arrow-narrow-up.svg"));
-        _decrease.setIcon(QIcon(":/icons/arrow-narrow-down.svg"));
+        _increase.setIcon(ThemedIcon::get(":/icons/arrow-narrow-up.svg"));
+        _decrease.setIcon(ThemedIcon::get(":/icons/arrow-narrow-down.svg"));
     }
 
     else if (_direction==Horizontal)
     {
-        _decrease.setIcon(QIcon(":/icons/arrow-narrow-left.svg"));
-        _increase.setIcon(QIcon(":/icons/arrow-narrow-right.svg"));
+        _decrease.setIcon(ThemedIcon::get(":/icons/arrow-narrow-left.svg"));
+        _increase.setIcon(ThemedIcon::get(":/icons/arrow-narrow-right.svg"));
     }
 }

--- a/libs/mouse/src/MouseCursorInfos.cpp
+++ b/libs/mouse/src/MouseCursorInfos.cpp
@@ -21,6 +21,7 @@
 #include <QApplication>
 #include <QPainter>
 #include <QLocale>
+#include "ThemedIcon.h"
 
 MouseCursorInfos::MouseCursorInfos(QWidget *parent):
     QWidget(parent),
@@ -142,7 +143,7 @@ void MouseCursorInfos::paintEvent(QPaintEvent *event)
     qp.drawRect(rec2);
 
     // Draw image.
-    QPixmap pixmap = QIcon(":/icons/mouse-2.svg").pixmap(16, 16);
+    QPixmap pixmap = ThemedIcon::get(":/icons/mouse-2.svg").pixmap(16, 16);
     int left=10;
     int top=(rec2.height()-pixmap.height())/2;
     QRect r(10+left, 10+top, pixmap.width(), pixmap.height());

--- a/libs/surface-results/src/SurfaceProperties.cpp
+++ b/libs/surface-results/src/SurfaceProperties.cpp
@@ -24,6 +24,7 @@
 #include <QPainter>
 #include <QLocale>
 #include <Log.h>
+#include "ThemedIcon.h"
 
 SurfaceProperties::SurfaceProperties(QWidget *parent):
     QWidget(parent),
@@ -106,7 +107,7 @@ SurfaceProperties::SurfaceProperties(QWidget *parent):
 
     translate();
 
-    _pixmap = QIcon(":/icons/fingerprint.svg").pixmap(16, 16);
+    _pixmap = ThemedIcon::get(":/icons/fingerprint.svg").pixmap(16, 16);
 
     statesChanged();
 }
@@ -188,7 +189,7 @@ void SurfaceProperties::paintEvent(QPaintEvent *event)
     qp.drawRect(rec2);
 
     // Draw image.
-    QPixmap pixmap = QIcon(":/icons/fingerprint.svg").pixmap(16, 16);
+    QPixmap pixmap = ThemedIcon::get(":/icons/fingerprint.svg").pixmap(16, 16);
     int left=10;
     int top=(rec2.height()-pixmap.height())/2;
     QRect r(10+left, 10+top, pixmap.width(), pixmap.height());

--- a/libs/temperature/src/HumidityDisplayer.cpp
+++ b/libs/temperature/src/HumidityDisplayer.cpp
@@ -23,6 +23,7 @@
 #include <QPainter>
 #include <QLocale>
 #include <Log.h>
+#include "ThemedIcon.h"
 
 HumidityDisplayer::HumidityDisplayer(QWidget *parent):
     QWidget(parent),
@@ -113,7 +114,7 @@ void HumidityDisplayer::translate()
 
 void HumidityDisplayer::applyTheme()
 {
-    _pixmap = QIcon(":/icons/droplets.svg").pixmap(16, 16);
+    _pixmap = ThemedIcon::get(":/icons/droplets.svg").pixmap(16, 16);
     update();
 }
 

--- a/libs/temperature/src/TemperatureDisplayer.cpp
+++ b/libs/temperature/src/TemperatureDisplayer.cpp
@@ -22,6 +22,7 @@
 #include <QPainter>
 #include <QLocale>
 #include <Log.h>
+#include "ThemedIcon.h"
 
 TemperatureDisplayer::TemperatureDisplayer(QWidget *parent):
     QWidget(parent),
@@ -49,7 +50,7 @@ TemperatureDisplayer::TemperatureDisplayer(QWidget *parent):
     translate();
     statesChanged();
 
-    _pixmap = QIcon(":/icons/temperature-sun.svg").pixmap(16, 16);
+    _pixmap = ThemedIcon::get(":/icons/temperature-sun.svg").pixmap(16, 16);
 }
 
 TemperatureDisplayer::~TemperatureDisplayer()

--- a/libs/themed-icons/include/ThemedIcon.h
+++ b/libs/themed-icons/include/ThemedIcon.h
@@ -1,0 +1,31 @@
+#ifndef THEMEDICON_H
+#define THEMEDICON_H
+
+#include <QIcon>
+#include <QString>
+
+/*! \brief Fabrique d'icones theme-aware.
+ *
+ *  Remplace les appels directs QIcon(":/icons/x.svg") par
+ *  ThemedIcon::get(":/icons/x.svg"). L'icone retournee est adossee a un
+ *  ThemedIconEngine qui recolorise le SVG selon la palette applicative a
+ *  chaque rendu (trait -> WindowText, interieur de case -> Base).
+ *
+ *  Migration : remplacer dans tout le code
+ *      QIcon(":/icons/copy.svg")
+ *  par
+ *      ThemedIcon::get(":/icons/copy.svg")
+ *
+ *  Note "a chaud" (pour une PR ulterieure) : un QIconEngine recalcule la
+ *  couleur a chaque paint(), mais Qt ne repeint pas spontanement toutes les
+ *  icones quand la palette change. Pour un basculement clair/sombre sans
+ *  redemarrage, il faudra, a la reception de QEvent::ApplicationPaletteChange,
+ *  forcer le rafraichissement des widgets concernes (update()).
+ */
+namespace ThemedIcon
+{
+    //! Retourne une QIcon recolorisable a partir d'une ressource SVG.
+    QIcon get(const QString& resourcePath);
+}
+
+#endif // THEMEDICON_H

--- a/libs/themed-icons/include/ThemedIconEngine.h
+++ b/libs/themed-icons/include/ThemedIconEngine.h
@@ -1,0 +1,69 @@
+#ifndef THEMEDICONENGINE_H
+#define THEMEDICONENGINE_H
+
+#include <QIconEngine>
+#include <QByteArray>
+#include <QString>
+
+/*! \brief Moteur d'icone "theme-aware" pour les SVG Tabler du projet.
+ *
+ *  Probleme resolu :
+ *  Les 63 icones SVG utilisent stroke="currentColor". QtSvg (SVG Tiny) ne gere
+ *  pas correctement currentColor : il rend alors en noir, ce qui les rend
+ *  quasi invisibles en theme sombre. Par ailleurs, 5 icones de case a cocher
+ *  (dxf-on/off, image-on/off, save-as) ont un interieur de case en
+ *  fill:#ffffff code en dur, qui doit suivre la couleur de FOND, pas celle du
+ *  trait.
+ *
+ *  Approche :
+ *  A chaque rendu, on lit la couleur courante de la palette applicative et on
+ *  reecrit le contenu du SVG avant de le confier a QSvgRenderer :
+ *    - currentColor      -> palette WindowText  (le trait : visible en clair ET sombre)
+ *    - fill:#ffffff       -> palette Base        (l'interieur des cases : suit le fond)
+ *  Le rendu suit ainsi automatiquement tout changement de palette (la mise a
+ *  jour effective des widgets a chaud necessite en plus de propager un
+ *  QEvent::PaletteChange ; voir ThemedIcon::installAutoRefresh()).
+ *
+ *  Le mode QIcon::Disabled est emule (QSvgRenderer n'ayant pas de notion de
+ *  mode, ni en Qt6) en reduisant l'opacite, approche heritee d'OpenMW.
+ *
+ *  Cible : Qt6. currentColor n'est toujours pas resolu par QSvgRenderer en
+ *  Qt6 ; la substitution de chaine reste donc la methode adaptee.
+ */
+class ThemedIconEngine : public QIconEngine
+{
+public:
+    //! Construit le moteur a partir d'une ressource SVG (ex: ":/icons/copy.svg").
+    explicit ThemedIconEngine(const QString& resourcePath);
+
+    //! Rend l'icone dans \a painter, sur le rectangle \a rect.
+    void paint(QPainter* painter, const QRect& rect,
+               QIcon::Mode mode, QIcon::State state) override;
+
+    //! Pixmap a la taille demandee (delegue a scaledPixmap, scale=1).
+    QPixmap pixmap(const QSize& size, QIcon::Mode mode,
+                   QIcon::State state) override;
+
+    //! Pixmap HiDPI : \a scale vaut typiquement le device pixel ratio.
+    //! Virtuelle directe depuis Qt6 (en Qt5 elle passait par virtual_hook).
+    QPixmap scaledPixmap(const QSize& size, QIcon::Mode mode,
+                         QIcon::State state, qreal scale) override;
+
+    //! Clone requis par QIcon (copie profonde du SVG source).
+    QIconEngine* clone() const override;
+
+    //! Nom de l'engine (utile au debug / serialisation).
+    QString key() const override;
+
+private:
+    //! Rend le SVG recolorise dans un pixmap de \a size px physiques.
+    QPixmap renderColored(const QSize& size, qreal dpr, QIcon::Mode mode) const;
+
+    //! Renvoie le SVG source avec les couleurs substituees selon la palette.
+    QByteArray themedSvg(QIcon::Mode mode) const;
+
+    QString    m_resourcePath; //!< Chemin de ressource d'origine (pour clone/key).
+    QByteArray m_svgTemplate;  //!< Contenu brut du SVG, charge une fois.
+};
+
+#endif // THEMEDICONENGINE_H

--- a/libs/themed-icons/src/ThemedIcon.cpp
+++ b/libs/themed-icons/src/ThemedIcon.cpp
@@ -1,0 +1,11 @@
+#include "ThemedIcon.h"
+#include "ThemedIconEngine.h"
+
+namespace ThemedIcon
+{
+    QIcon get(const QString& resourcePath)
+    {
+        // QIcon prend possession de l'engine et gere sa duree de vie.
+        return QIcon(new ThemedIconEngine(resourcePath));
+    }
+}

--- a/libs/themed-icons/src/ThemedIconEngine.cpp
+++ b/libs/themed-icons/src/ThemedIconEngine.cpp
@@ -1,0 +1,128 @@
+#include "ThemedIconEngine.h"
+
+#include <QApplication>
+#include <QPalette>
+#include <QPainter>
+#include <QPixmap>
+#include <QFile>
+#include <QSvgRenderer>
+#include <QColor>
+
+namespace
+{
+    //! Convertit une QColor en notation SVG "#rrggbb".
+    QString toSvgHex(const QColor& c)
+    {
+        return c.name(QColor::HexRgb); // ex: "#1e1e1e"
+    }
+}
+
+ThemedIconEngine::ThemedIconEngine(const QString& resourcePath)
+    : m_resourcePath(resourcePath)
+{
+    // Charge le SVG une seule fois ; la recoloration se fera a chaque rendu.
+    QFile f(resourcePath);
+    if (f.open(QIODevice::ReadOnly))
+        m_svgTemplate = f.readAll();
+}
+
+QByteArray ThemedIconEngine::themedSvg(QIcon::Mode mode) const
+{
+    const QPalette pal = QApplication::palette();
+
+    // Couleur du trait : le texte/avant-plan. Suit clair comme sombre.
+    QColor stroke = pal.color(QPalette::WindowText);
+    // Couleur de l'interieur des cases a cocher : le fond.
+    const QColor fill = pal.color(QPalette::Base);
+
+    // Pour le mode "selected" (survol/selection dans une vue), Qt fournit
+    // une couleur de texte dediee plus lisible sur fond de selection.
+    if (mode == QIcon::Selected)
+        stroke = pal.color(QPalette::HighlightedText);
+
+    QByteArray svg = m_svgTemplate;
+
+    // 1) Le trait : remplacer currentColor par la couleur d'avant-plan.
+    //    Couvre stroke="currentColor" et fill="currentColor".
+    svg.replace("currentColor", toSvgHex(stroke).toUtf8());
+
+    // 2) L'interieur des cases : le blanc code en dur suit le fond.
+    //    Couvre la forme CSS (style="fill:#ffffff") et l'attribut (fill="#ffffff"),
+    //    en #fff comme en #ffffff, insensible a la casse via les deux variantes.
+    const QByteArray fillHex = toSvgHex(fill).toUtf8();
+    svg.replace("fill:#ffffff", "fill:" + fillHex);
+    svg.replace("fill:#FFFFFF", "fill:" + fillHex);
+    svg.replace("fill:#fff;",   "fill:" + fillHex + ";");
+    svg.replace("fill=\"#ffffff\"", "fill=\"" + fillHex + "\"");
+    svg.replace("fill=\"#FFFFFF\"", "fill=\"" + fillHex + "\"");
+
+    return svg;
+}
+
+QPixmap ThemedIconEngine::renderColored(const QSize& size, qreal dpr,
+                                        QIcon::Mode mode) const
+{
+    if (m_svgTemplate.isEmpty() || size.isEmpty())
+        return QPixmap();
+
+    // Rend a la resolution physique (taille logique * device pixel ratio)
+    // pour rester net en HiDPI.
+    const QSize physical = size * dpr;
+
+    QPixmap pm(physical);
+    pm.fill(Qt::transparent);
+
+    QSvgRenderer renderer(themedSvg(mode));
+
+    QPainter p(&pm);
+    p.setRenderHint(QPainter::Antialiasing, true);
+    p.setRenderHint(QPainter::SmoothPixmapTransform, true);
+
+    // Mode desactive : QSvgRenderer ne gere pas QIcon::Disabled, on emule
+    // en abaissant l'opacite (approche OpenMW).
+    if (mode == QIcon::Disabled)
+        p.setOpacity(0.35);
+
+    renderer.render(&p);
+    p.end();
+
+    pm.setDevicePixelRatio(dpr);
+    return pm;
+}
+
+void ThemedIconEngine::paint(QPainter* painter, const QRect& rect,
+                             QIcon::Mode mode, QIcon::State state)
+{
+    Q_UNUSED(state); // l'etat on/off est porte par le contenu du SVG lui-meme
+    const qreal dpr = painter->device()
+                          ? painter->device()->devicePixelRatioF()
+                          : 1.0;
+    const QPixmap pm = renderColored(rect.size(), dpr, mode);
+    painter->drawPixmap(rect, pm);
+}
+
+QPixmap ThemedIconEngine::pixmap(const QSize& size, QIcon::Mode mode,
+                                 QIcon::State state)
+{
+    // Delegue a scaledPixmap : en Qt6 c'est le point d'entree privilegie,
+    // QIcon appelant scaledPixmap avec le bon scale pour le HiDPI.
+    const qreal dpr = qApp ? qApp->devicePixelRatio() : 1.0;
+    return scaledPixmap(size, mode, state, dpr);
+}
+
+QPixmap ThemedIconEngine::scaledPixmap(const QSize& size, QIcon::Mode mode,
+                                       QIcon::State state, qreal scale)
+{
+    Q_UNUSED(state); // l'etat on/off est porte par le contenu du SVG lui-meme
+    return renderColored(size, scale, mode);
+}
+
+QIconEngine* ThemedIconEngine::clone() const
+{
+    return new ThemedIconEngine(m_resourcePath);
+}
+
+QString ThemedIconEngine::key() const
+{
+    return QStringLiteral("ThemedIconEngine");
+}

--- a/libs/volume-infos/src/VolumeProperties.cpp
+++ b/libs/volume-infos/src/VolumeProperties.cpp
@@ -24,6 +24,7 @@
 #include <StatesManager.h>
 #include <model/Volume.h>
 #include <QPainter>
+#include "ThemedIcon.h"
 
 VolumeProperties::VolumeProperties(QWidget *parent):
     QWidget(parent),
@@ -136,7 +137,7 @@ void VolumeProperties::paintEvent(QPaintEvent *event)
     qp.drawRect(rec2);
 
     // Draw image.
-    QPixmap pixmap = QIcon(":/icons/rectangle.svg").pixmap(16, 16);
+    QPixmap pixmap = ThemedIcon::get(":/icons/rectangle.svg").pixmap(16, 16);
     int left=10;
     int top=(rec2.height()-pixmap.height())/2;
     QRect r(10+left, 10+top, pixmap.width(), pixmap.height());

--- a/src/MainMenu.cpp
+++ b/src/MainMenu.cpp
@@ -63,6 +63,7 @@
 #include <Log.h>
 #include <QDir>
 #include <QUrl>
+#include "ThemedIcon.h"
 
 MainMenu::MainMenu(QWidget *parent):
     QMenuBar(parent),
@@ -514,52 +515,52 @@ void MainMenu::translate()
 
 void MainMenu::applyTheme()
 {
-    _newDocumentAction.setIcon(QIcon(":/icons/file.svg"));
-    _openDocumentAction.setIcon(QIcon(":/icons/folder-open.svg"));
-    _saveDocumentAction.setIcon(QIcon(":/icons/device-floppy.svg"));
-    _saveDocumentAsAction.setIcon(QIcon(":/icons/save-as.svg"));
-    _cutAction.setIcon(QIcon(":/icons/cut.svg"));
-    _copyAction.setIcon(QIcon(":/icons/copy.svg"));
-    _pasteAction.setIcon(QIcon(":/icons/clipboard.svg"));
-    _undoAction.setIcon(QIcon(":/icons/arrow-back-up.svg"));
-    _redoAction.setIcon(QIcon(":/icons/arrow-forward-up.svg"));
-    _aboutAction.setIcon(QIcon(":/icons/info-circle.svg"));
+    _newDocumentAction.setIcon(ThemedIcon::get(":/icons/file.svg"));
+    _openDocumentAction.setIcon(ThemedIcon::get(":/icons/folder-open.svg"));
+    _saveDocumentAction.setIcon(ThemedIcon::get(":/icons/device-floppy.svg"));
+    _saveDocumentAsAction.setIcon(ThemedIcon::get(":/icons/save-as.svg"));
+    _cutAction.setIcon(ThemedIcon::get(":/icons/cut.svg"));
+    _copyAction.setIcon(ThemedIcon::get(":/icons/copy.svg"));
+    _pasteAction.setIcon(ThemedIcon::get(":/icons/clipboard.svg"));
+    _undoAction.setIcon(ThemedIcon::get(":/icons/arrow-back-up.svg"));
+    _redoAction.setIcon(ThemedIcon::get(":/icons/arrow-forward-up.svg"));
+    _aboutAction.setIcon(ThemedIcon::get(":/icons/info-circle.svg"));
 
-    _selectionModeAction.setIcon(QIcon(":/icons/pointer.svg"));
-    _addRectangleModeAction.setIcon(QIcon(":/icons/rectangle.svg"));
+    _selectionModeAction.setIcon(ThemedIcon::get(":/icons/pointer.svg"));
+    _addRectangleModeAction.setIcon(ThemedIcon::get(":/icons/rectangle.svg"));
 
-    _getMaterialModeAction.setIcon(QIcon(":/icons/color-picker.svg"));
-    _setPhysicModeAction.setIcon(QIcon(":/icons/bucket-droplet.svg"));
-    _setEnvironmentModeAction.setIcon(QIcon(":/icons/layout-collage.svg"));
+    _getMaterialModeAction.setIcon(ThemedIcon::get(":/icons/color-picker.svg"));
+    _setPhysicModeAction.setIcon(ThemedIcon::get(":/icons/bucket-droplet.svg"));
+    _setEnvironmentModeAction.setIcon(ThemedIcon::get(":/icons/layout-collage.svg"));
 
-    _computeAction.setIcon(QIcon(":/icons/player-play.svg"));
+    _computeAction.setIcon(ThemedIcon::get(":/icons/player-play.svg"));
 
-    _frontAction.setIcon(QIcon(":/icons/stack-front.svg"));
-    _backAction.setIcon(QIcon(":/icons/stack-back.svg"));
+    _frontAction.setIcon(ThemedIcon::get(":/icons/stack-front.svg"));
+    _backAction.setIcon(ThemedIcon::get(":/icons/stack-back.svg"));
 
-    _frontOneShotAction.setIcon(QIcon(":/icons/stack-forward.svg"));
-    _backOneShotAction.setIcon(QIcon(":/icons/stack-backward.svg"));
+    _frontOneShotAction.setIcon(ThemedIcon::get(":/icons/stack-forward.svg"));
+    _backOneShotAction.setIcon(ThemedIcon::get(":/icons/stack-backward.svg"));
 
-    _fitAction.setIcon(QIcon(":/icons/zoom-scan.svg"));
-    _zoomInAction.setIcon(QIcon(":/icons/zoom-in.svg"));
-    _zoomOutAction.setIcon(QIcon(":/icons/zoom-out.svg"));
+    _fitAction.setIcon(ThemedIcon::get(":/icons/zoom-scan.svg"));
+    _zoomInAction.setIcon(ThemedIcon::get(":/icons/zoom-in.svg"));
+    _zoomOutAction.setIcon(ThemedIcon::get(":/icons/zoom-out.svg"));
 
-    _copy2DModelTo1DModel.setIcon(QIcon(":/icons/restore.svg"));
-    _toogleEn13370.setIcon(QIcon(":/icons/calculator.svg"));
+    _copy2DModelTo1DModel.setIcon(ThemedIcon::get(":/icons/restore.svg"));
+    _toogleEn13370.setIcon(ThemedIcon::get(":/icons/calculator.svg"));
     
-    _addPolyline.setIcon(QIcon(":/icons/polygon.svg"));
-    _addPoint.setIcon(QIcon(":/icons/transform-point-bottom-left.svg"));
-    _addCircleModeAction.setIcon(QIcon(":/icons/circle.svg"));
-    _addEllipseModeAction.setIcon(QIcon(":/icons/ellipse.svg"));
+    _addPolyline.setIcon(ThemedIcon::get(":/icons/polygon.svg"));
+    _addPoint.setIcon(ThemedIcon::get(":/icons/transform-point-bottom-left.svg"));
+    _addCircleModeAction.setIcon(ThemedIcon::get(":/icons/circle.svg"));
+    _addEllipseModeAction.setIcon(ThemedIcon::get(":/icons/ellipse.svg"));
 
-    _addImageAction.setIcon(QIcon(":/icons/photo.svg"));
-    _addDxfAction.setIcon(QIcon(":/icons/photo-code.svg"));
+    _addImageAction.setIcon(ThemedIcon::get(":/icons/photo.svg"));
+    _addDxfAction.setIcon(ThemedIcon::get(":/icons/photo-code.svg"));
 
-    _getLength.setIcon(QIcon(":/icons/ruler-3.svg"));
-    _getAngle.setIcon(QIcon(":/icons/angle.svg"));
+    _getLength.setIcon(ThemedIcon::get(":/icons/ruler-3.svg"));
+    _getAngle.setIcon(ThemedIcon::get(":/icons/angle.svg"));
 
-    _addText.setIcon(QIcon(":/icons/text-color.svg"));
-    _addArrow.setIcon(QIcon(":/icons/arrow-bear-right.svg"));
+    _addText.setIcon(ThemedIcon::get(":/icons/text-color.svg"));
+    _addArrow.setIcon(ThemedIcon::get(":/icons/arrow-bear-right.svg"));
 
     updateImagesVisibility();
 }
@@ -567,9 +568,9 @@ void MainMenu::applyTheme()
 void MainMenu::updateImagesVisibility()
 {
     if (StatesManager::instance()->showImages())
-        _imagesVisibilityAction.setIcon(QIcon(":/icons/image-on.svg"));
+        _imagesVisibilityAction.setIcon(ThemedIcon::get(":/icons/image-on.svg"));
     else
-        _imagesVisibilityAction.setIcon(QIcon(":/icons/image-off.svg"));
+        _imagesVisibilityAction.setIcon(ThemedIcon::get(":/icons/image-off.svg"));
 
     if (StatesManager::instance()->showImages())
         _imagesVisibilityAction.setText(_tr("HideImages"));
@@ -577,9 +578,9 @@ void MainMenu::updateImagesVisibility()
         _imagesVisibilityAction.setText(_tr("ShowImages"));
 
     if (StatesManager::instance()->showDxf())
-        _dxfVisibilityAction.setIcon(QIcon(":/icons/dxf-on.svg"));
+        _dxfVisibilityAction.setIcon(ThemedIcon::get(":/icons/dxf-on.svg"));
     else
-        _dxfVisibilityAction.setIcon(QIcon(":/icons/dxf-off.svg"));
+        _dxfVisibilityAction.setIcon(ThemedIcon::get(":/icons/dxf-off.svg"));
 
     if (StatesManager::instance()->showDxf())
         _dxfVisibilityAction.setText(_tr("HideDxf"));
@@ -1752,7 +1753,7 @@ void MainMenu::exceptionCaught(ErrorHandler::ErrorCode code)
     dialog.setWindowModality(Qt::ApplicationModal);
     QIcon icon(":/icon.png");
     dialog.setWindowIcon(icon);
-    dialog.setIconPixmap(QIcon(":/icons/alert-circle.svg").pixmap(16, 16));
+    dialog.setIconPixmap(ThemedIcon::get(":/icons/alert-circle.svg").pixmap(16, 16));
     dialog.exec();
 }
 

--- a/src/reports/Report.cpp
+++ b/src/reports/Report.cpp
@@ -26,6 +26,7 @@
 #include <QPainter>
 #include <Log.h>
 #include <QUrl>
+#include "ThemedIcon.h"
 
 Report::Report(QWidget *parent):
     QWidget(parent),
@@ -69,9 +70,9 @@ Report::~Report()
 
 void Report::setIcons()
 {
-    _export.setIcon(QIcon(":/icons/report.svg"));
-    _pdfExport->setIcon(QIcon(":/icons/file-type-pdf.svg"));
-    _exportMenuAction->setIcon(QIcon(":/icons/file-type-docx.svg"));
+    _export.setIcon(ThemedIcon::get(":/icons/report.svg"));
+    _pdfExport->setIcon(ThemedIcon::get(":/icons/file-type-pdf.svg"));
+    _exportMenuAction->setIcon(ThemedIcon::get(":/icons/file-type-docx.svg"));
     _export.setIconSize(QSize(24, 24));
 }
 


### PR DESCRIPTION
## Context

First step toward dark mode, as discussed in #21 : focusing on icon rendering
rather than a full theme system, to make the application usable on a dark
background, starting with the icons.

Icons use `stroke="currentColor"`, which `QSvgRenderer` does not resolve — they
render near-black and disappear on a dark background. This PR makes them adapt to
the current Qt palette at load time, as you suggested.

## Approach

`ThemedIconEngine` (a `QIconEngine`) recolors each SVG at paint time from the
application palette:

- `currentColor` → `QPalette::WindowText` (stroke, readable in light and dark);
- hardcoded checkbox interior `fill:#ffffff` (in the `dxf-on/off`, `image-on/off`
  state icons) → `QPalette::Base` (follows the background instead of staying white).

Since `QSvgRenderer` resolves neither `currentColor` nor palette roles, recoloring
rewrites the SVG buffer before rendering. As it has no `QIcon::Mode`, the disabled
state is emulated via painter opacity.

A factory `ThemedIcon::get(":/icons/x.svg")` replaces the direct `QIcon(...)` calls.

## Changes

- new self-contained `libs/themed-icons/` module;
- `CMakeLists.txt`: add the `Svg` component, link `Qt::Svg`;
- migrate `QIcon(":/icons/*.svg")` call sites in `src/` and `libs/`.

PNG logos (`:/icon.png`) and `QMessageBox` icons are left unchanged (not
palette-dependent).

## Commits

1. **Add themed-icons module** — engine, factory, build integration (unused yet,
   build stays green).
2. **Use ThemedIcon::get() for all SVG icon loads** — switches every call site over;
   enables readable icons in dark mode.

## Testing

Built (on Archlinux only) with Qt 6.4 / GCC, checked in light and dark palettes (Fusion): toolbar,
button and list icons render light-on-dark; state icons (`dxf`, `image`) show a
background-following interior and toggle correctly. Screenshots below.

## Good base for full theming

- icons already follow the palette (recolored every paint) → a future light/dark
  toggle mainly needs to switch the palette and refresh, not rewrite icon handling;
- ~50 scattered `QIcon(...)` calls now go through one factory;
- establishes the role convention (stroke → `WindowText`, surfaces → `Base`).

## Follow-up

Statically-cached `QPixmap` icons (a few custom-painted widgets) take the right
color at creation — fine for a startup-fixed theme. Live switching would also need
a refresh on `QEvent::ApplicationPaletteChange` / `QStyleHints::colorScheme()`.
<img width="714" height="720" alt="Conducteo-clair" src="https://github.com/user-attachments/assets/28c53593-fd9a-46e7-be55-04fcd3acb34e" />
<img width="714" height="720" alt="Conducteo-sombre" src="https://github.com/user-attachments/assets/0dc04043-d601-4d8e-a366-5a6f8897eea7" />